### PR TITLE
Add remove_action calls to unregister mu plugin sso handlers

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -24,6 +24,11 @@ function eig_module_sso_load() {
 
 	require dirname( __FILE__ ) . '/functions.php';
 
+	// Unregister actions from the sso.php mu-plugin in case they exist
+	// This ensures that this code always takes priority for SSO handling
+	remove_action( 'wp_ajax_nopriv_sso-check', 'sso_check' );
+	remove_action( 'wp_ajax_sso-check', 'sso_check' );
+
 	add_action( 'wp_ajax_nopriv_sso-check', 'eig_sso_handler' );
 	add_action( 'wp_ajax_sso-check', 'eig_sso_handler' );
 


### PR DESCRIPTION
When the [`sso.php` mu-plugin](https://github.com/bluehost/wp-sso-mu-plugin) file is present on a site, it takes priority over this module because mu-plugins are loaded first and its admin-ajax `sso-check` action callbacks are registered with the same priority as this module. 

This essentially means that no code from this module gets run. This issue presented itself when the redirects to the Bluehost dashboard instead of the standard wp-admin dashboard were not functioning correctly. 

This PR simply attempts to unregister those callbacks, so if they are present—regardless of priority—this module will still handle the SSO.